### PR TITLE
Limit the conversation history

### DIFF
--- a/src/server/api/routers/chats.ts
+++ b/src/server/api/routers/chats.ts
@@ -65,7 +65,9 @@ export const chatRouter = createTRPCRouter({
         },
       });
 
-      const messages = chat.messages;
+      const totalMessageLength = chat.messages.length;
+      const messages = chat.messages
+        .slice(totalMessageLength > 10 ? -10 : totalMessageLength * -1);
 
       const openai = await getOpenaiClient();
 
@@ -101,12 +103,12 @@ export const chatRouter = createTRPCRouter({
             create: [
               {
                 text: input.message,
-                position: messages.length,
+                position: totalMessageLength,
                 role: "user",
               },
               {
                 text: content,
-                position: messages.length + 1,
+                position: totalMessageLength + 1,
                 role: "assistant",
               },
             ],


### PR DESCRIPTION
This PR addresses #13. On longer conversations, the client does not limit the conversation history which is sent to the api. This causes the request to exceed the fixed token limit of 4096 in total. 
This PR limits the request to contain the last 5 questions and their replies at max. In future versions, this could be a configurable option.